### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 * * * *' # every hour
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run-script:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/notaworker/automations/security/code-scanning/2](https://github.com/notaworker/automations/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's actions, it primarily needs read access to the repository contents. Since no write actions (e.g., creating issues or pull requests) are performed, we will set `contents: read` as the only permission.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
